### PR TITLE
Added Tensorflow 1.0 compatability

### DIFF
--- a/encoder.py
+++ b/encoder.py
@@ -65,7 +65,7 @@ def mlstm(inputs, c, h, M, ndim, scope='lstm', wn=False):
     for idx, x in enumerate(inputs):
         m = tf.matmul(x, wmx)*tf.matmul(h, wmh)
         z = tf.matmul(x, wx) + tf.matmul(m, wh) + b
-        i, f, o, u = tf.split(1, 4, z)
+        i, f, o, u = tf.split(axis=1, num_or_size_splits=4, value=z)
         i = tf.nn.sigmoid(i)
         f = tf.nn.sigmoid(f)
         o = tf.nn.sigmoid(o)
@@ -81,22 +81,22 @@ def mlstm(inputs, c, h, M, ndim, scope='lstm', wn=False):
             h = o*tf.tanh(c)
         inputs[idx] = h
         cs.append(c)
-    cs = tf.pack(cs)
+    cs = tf.stack(cs)
     return inputs, cs, c, h
 
 
 def model(X, S, M=None, reuse=False):
-    nsteps = X.get_shape()[1]
-    cstart, hstart = tf.unpack(S, num=hps.nstates)
+    nsteps = X.get_shape()[1].value
+    cstart, hstart = tf.unstack(S, num=hps.nstates)
     with tf.variable_scope('model', reuse=reuse):
         words = embd(X, hps.nembd)
-        inputs = [tf.squeeze(v, [1]) for v in tf.split(1, nsteps, words)]
+        inputs = [tf.squeeze(v, [1]) for v in tf.split(axis=1, num_or_size_splits=nsteps, value=words)]
         hs, cells, cfinal, hfinal = mlstm(
             inputs, cstart, hstart, M, hps.nhidden, scope='rnn', wn=hps.rnn_wn)
-        hs = tf.reshape(tf.concat(1, hs), [-1, hps.nhidden])
+        hs = tf.reshape(tf.concat(axis=1, values=hs), [-1, hps.nhidden])
         logits = fc(
             hs, hps.nvocab, act=lambda x: x, wn=hps.out_wn, scope='out')
-    states = tf.pack([cfinal, hfinal], 0)
+    states = tf.stack([cfinal, hfinal], 0)
     return cells, states, logits
 
 
@@ -143,7 +143,7 @@ class Model(object):
         cells, states, logits = model(X, S, M, reuse=False)
 
         sess = tf.Session()
-        tf.initialize_all_variables().run(session=sess)
+        tf.global_variables_initializer().run(session=sess)
 
         def seq_rep(xmb, mmb, smb):
             return sess.run(states, {X: xmb, M: mmb, S: smb})


### PR DESCRIPTION
Tensorflow v1.0 included a lot of changes to keeping up to date is important. A lot of things were fixable with the tensorflow upgrade script but changes to tf.split() caused errors.

    Traceback (most recent call last):
      File "encoder.py", line 209, in <module>
        mdl = Model()
      File "encoder.py", line 143, in __init__
        cells, states, logits = model(X, S, M, reuse=False)
      File "encoder.py", line 93, in model
        inputs = [tf.squeeze(v, [1]) for v in tf.split(axis=1, num_or_size_splits=nsteps, value=words)]
      File "/Users/rupertdeese/.pyenv/versions/3.5.0/lib/python3.5/site-packages/tensorflow/python/ops/array_ops.py", line 1203, in split
        num = size_splits_shape.dims[0]
    IndexError: list index out of range

This error was because nsteps is passed into tf.split as the num_os_size_splits argument but nsteps is a "Dimension" this was fine when tf.split() looked like this

    def split(split_dim, num_split, value, name="split"):
        return gen_array_ops._split(split_dim=split_dim,
                              num_split=num_split,
                              value=value,
                              name=name)

in v1.0 tf.split() changed not only the order of arguments but the function is now

    def split(value, num_or_size_splits, axis=0, num=None, name="split"):
        if isinstance(num_or_size_splits, six.integer_types):
            return gen_array_ops._split(
                split_dim=axis, num_split=num_or_size_splits, value=value, name=name)
        else:
            size_splits = ops.convert_to_tensor(num_or_size_splits)
            if num is None:
                size_splits_shape = size_splits.get_shape()
                num = size_splits_shape.dims[0]
            if num._value is None:
                raise ValueError("Cannot infer num from shape %s" % num_or_size_splits)
            return gen_array_ops._split_v(
                value=value,
                size_splits=size_splits,
                split_dim=axis,
                num_split=num,
                name=name)

Now when tf.split() is called, if isinstance(num_or_size_splits, six.integer_types): returns false and the code tries to get the Dimension's shape but it is an empty list so .dims[0] fails.

This pull request fixes the simple argument switching, function renaming incompatibilities in encoder.py and also fixes the above bug concerning tf.split()