### PR TITLE
Add sequence_features

### DIFF
--- a/encoder.py
+++ b/encoder.py
@@ -201,8 +201,23 @@ class Model(object):
             Fs = np.concatenate(Fs, axis=1).transpose(1, 0, 2)
             return Fs
 
+        def sequence_features(x, index):
+            x = preprocess(x)
+            n = len(x)
+            smb = np.zeros((2, 1, hps.nhidden))
+            fs = []
+            for step in range(0, ceil_round_step(n, nsteps), nsteps):
+                start = step
+                end = step+nsteps
+                xsubseq = x[start:end]
+                xmb, mmb = batch_pad([xsubseq], 1, nsteps)
+                seq_c, smb = sess.run([cells, states], {X: xmb, S: smb, M: mmb})
+                fs.append(seq_c[-len(xsubseq):, 0, index])
+            return np.concatenate(fs)
+
         self.transform = transform
         self.cell_transform = cell_transform
+        self.sequence_features = sequence_features
 
 
 if __name__ == '__main__':
@@ -210,3 +225,4 @@ if __name__ == '__main__':
     text = ['demo!']
     text_features = mdl.transform(text)
     print(text_features.shape)
+


### PR DESCRIPTION
Extract the value of a specific feature along the sequence, e.g., for the "sentiment neuron":
```python
>>> print(mdl.sequence_features('great product!', 2388))
[ 0.01258736  0.03544582  0.09762047  0.14658478  0.13112086  0.1182572
  0.20108429  0.55418217  0.54974681  0.53858727  0.52452445  0.51187605
  0.50210464  0.48934704  0.50488353  0.83780205  1.1202054 ]
```
Includes padding (2 bytes in front, one byte in end). Only accepts single string as input.