### PR TITLE
Added generation (resolves #12)

### DIFF
--- a/encoder.py
+++ b/encoder.py
@@ -202,6 +202,25 @@ class Model(object):
             return Fs
         
         def generate_sequence(x_start, override={}, sampling = 0, len_add = '.'):
+            """Continue a given sequence. 
+
+            Args:
+                x_start (string): The string to be continued.
+                override (dict): Values of the hidden state to override
+                  with keys of the dictionary as index.          
+                sampling (int): 0 greedy argmax, 2 weighted random from probabilty 
+                  distribution, 1 weighted but only once after each word.
+                len_add (int, string, None): 
+                  If int, the number of characters to be added.
+                  If string, returns after each contained character was seen once.
+
+            Returns:
+                The completed string including transformation and paddings from preprocessing.
+
+            Example:
+                generate_sequence("I couldn’t figure out", override= {2388 : 1.0})
+            """
+            
             len_start = len(x_start)
             x = bytearray(preprocess(x_start))
 

--- a/encoder.py
+++ b/encoder.py
@@ -200,9 +200,55 @@ class Model(object):
                 Fs.append(smb)
             Fs = np.concatenate(Fs, axis=1).transpose(1, 0, 2)
             return Fs
+        
+        def generate_sequence(x_start, override={}, sampling = 0, len_add = '.'):
+            len_start = len(x_start)
+            x = bytearray(preprocess(x_start))
 
+            string_terminate = isinstance(len_add, str)
+            len_end = (-1 if string_terminate else (len_start + len_add))
+
+            ndone = 0
+            last_chr = chr(x[-1])
+            smb = np.zeros((2, 1, hps.nhidden))
+
+            while True if string_terminate else ndone <= len_end:
+                xsubseq = x[ndone:ndone+nsteps]
+                ndone += len(xsubseq)
+                xmb, mmb = batch_pad([xsubseq], 1, nsteps)
+
+                #Override salient neurons
+                for neuron, value in override.items():
+                    smb[:, :, neuron] = value        
+
+                if ndone <= len_start:
+                    #Prime hidden state with full steps
+                    smb = sess.run(states, {X: xmb, S: smb, M: mmb})
+                else:
+                    #Incrementally add characters
+                    outs, smb = sess.run([logits, states], {X: xmb, S: smb, M: mmb})
+                    out = outs[-1]
+
+                    #Do uniform weighted sampling always or only after ' '
+                    if (sampling == 1 and last_chr == ' ') or sampling == 2:
+                        squashed = np.exp(out) / np.sum(np.exp(out), axis=0)
+                        last_chr = chr(np.random.choice(len(squashed), p=squashed))
+                    else:
+                        last_chr = chr(np.argmax(out))
+
+                x.append(ord(last_chr))
+
+                if string_terminate and (last_chr in len_add):
+                    len_add = len_add.replace(last_chr, "", 1)
+                    if len(len_add) == 0:
+                        break
+            
+            return(x.decode()) 
+        
+        
         self.transform = transform
         self.cell_transform = cell_transform
+        self.generate_sequence = generate_sequence
 
 
 if __name__ == '__main__':

--- a/test_generative.py
+++ b/test_generative.py
@@ -1,0 +1,36 @@
+from encoder import Model
+mdl = Model()
+
+base = "I couldn’t figure out"
+print("\'%s\'... --> (argmax sampling):" % base)
+
+#Overriden values are slightly on the extreme on either end of 
+#the sentiment's activation distribution
+positive = mdl.generate_sequence(base, override={2388 : 1.0})
+print("Positive sentiment (1 sentence): " + positive)
+negative = mdl.generate_sequence(base, override={2388 : -1.5}, len_add = 100)
+print("\nNegative sentiment (+100 chars):" + negative + '...')
+
+
+n = 3
+print("\n\n\'%s\'... --> (weighted samples after each word):" % base)
+
+print("Positive sentiment (%d examples, 2 sentences each):" %n)
+for i in range(n):
+    positive = mdl.generate_sequence(base, override={2388 : 1.0}, len_add = '..', sampling = 1)
+    print("(%d)%s" % (i, positive[1:]))
+    
+print("\nNegative sentiment (%d examples, 2 sentences each):" %n)
+for i in range(n):
+    positive = mdl.generate_sequence(base, override={2388 : -1.5}, len_add = '..', sampling = 1)
+    print("(%d)%s" % (i, positive[1:]))
+  
+
+print("\n\n\'%s\'... --> (weighted samples after each character):" % base)
+
+neutral = mdl.generate_sequence(base, len_add = '...', sampling = 2)
+print("Sentiment not influenced (3 sentences):" + neutral)
+neutral = mdl.generate_sequence(base, override={2388 : 0.0}, len_add = '...', sampling = 2)
+print("\nSentiment fixed to 0 (3 sentences):" + neutral)
+negative = mdl.generate_sequence(base, override={2388 : -1.0}, len_add = '...', sampling = 2)
+print("\nSligthly negative sentiment (3 sentences):" + negative)


### PR DESCRIPTION
Function `generate_sequence()` takes an initial string, a dictionary that overrides hidden states, the stopping condition,  and a mode for which (greedy) sampler to use. 
Usage:
`positive = mdl.generate_sequence(base_str, override={2388 : 1.0}, len_add = '..', sampling = 1)`
See docstring for further explanation.

The options are tested in test_generative.py. Sampling two sentences after _I couldn’t figure out_  with a fixed positive sentiment (2388 : 1.0) and stochastic sampling after separate words yields pretty convincing examples:
`I couldn’t figure out what all the complaints are about but I love it and I can’t wait to see what else she makes in the future. I have not stopped laughing out loud since the first book of hers I have read.`

Example with a negative sentiment (2388 : -1.5):
`I couldn’t figure out how to get the product to work with some trial version. Not even a 2 page document with a text appeared on the left hand side correctly.`