### PR TITLE
Global variable 'nloaded' needs to be zero, everytime Model is initialized.

### DIFF
--- a/encoder.py
+++ b/encoder.py
@@ -118,6 +118,9 @@ def batch_pad(xs, nbatch, nsteps):
 class Model(object):
 
     def __init__(self, nbatch=128, nsteps=64):
+        global nloaded
+        nloaded = 0
+        
         global hps
         hps = HParams(
             load_path='model_params/params.jl',


### PR DESCRIPTION
I tried using it in a Flask app. There's a global variable issue, so model doesn't work for 2nd time initialization. 'nloaded' is saturated to '13' in 'load_params'. So, the next time you call Model, 'nloaded' starts from 13, but not from 0.